### PR TITLE
docs: reference v2 in examples; update pnpm to v12.0.0-beta.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: '12.0.0-alpha.21'
+            version: '12.0.0-beta.4'
           - os: ubuntu-24.04-arm
-            version: '12.0.0-alpha.21'
+            version: '12.0.0-beta.4'
           - os: macos-latest
-            version: '12.0.0-alpha.21'
+            version: '12.0.0-beta.4'
           - os: windows-latest
-            version: '12.0.0-alpha.21'
+            version: '12.0.0-beta.4'
 
     steps:
       - uses: actions/checkout@v6
@@ -225,7 +225,7 @@ jobs:
       - id: pnpm
         uses: ./
         with:
-          version: '12.0.0-alpha.21'
+          version: '12.0.0-beta.4'
           runtime: node@${{ matrix.major }}
 
       - name: 'Test: node binary on PATH'
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./
         with:
-          version: '12.0.0-alpha.21'
+          version: '12.0.0-beta.4'
           runtime: bun@latest
       - name: 'Test: bun on PATH'
         run: |
@@ -282,7 +282,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./
         with:
-          version: '12.0.0-alpha.21'
+          version: '12.0.0-beta.4'
           runtime: deno@2
       - name: 'Test: deno on PATH'
         run: |
@@ -307,7 +307,7 @@ jobs:
           rm -f pnpm-lock.yaml
           cat > package.json <<'EOF'
           {
-            "packageManager": "pnpm@12.0.0-alpha.21",
+            "packageManager": "pnpm@12.0.0-beta.4",
             "devEngines": {
               "runtime": { "name": "node", "version": "^22.0.0", "onFail": "download" }
             },
@@ -364,7 +364,7 @@ jobs:
           rm -f pnpm-lock.yaml
           cat > package.json <<'EOF'
           {
-            "packageManager": "pnpm@12.0.0-alpha.21",
+            "packageManager": "pnpm@12.0.0-beta.4",
             "devEngines": {
               "runtime": { "name": "node", "version": "^20.0.0", "onFail": "download" }
             },
@@ -409,7 +409,7 @@ jobs:
           rm -f pnpm-lock.yaml
           cat > package.json <<'EOF'
           {
-            "packageManager": "pnpm@12.0.0-alpha.21",
+            "packageManager": "pnpm@12.0.0-beta.4",
             "devEngines": {
               "runtime": { "name": "node", "version": "^20.0.0", "onFail": "download" }
             }
@@ -446,7 +446,7 @@ jobs:
           rm -f pnpm-lock.yaml
           cat > package.json <<'EOF'
           {
-            "packageManager": "pnpm@12.0.0-alpha.21",
+            "packageManager": "pnpm@12.0.0-beta.4",
             "dependencies": {
               "is-odd": "3.0.1"
             }
@@ -456,7 +456,7 @@ jobs:
 
       - uses: ./
         with:
-          version: '12.0.0-alpha.21'
+          version: '12.0.0-beta.4'
           install: false
 
       - name: 'Test: node_modules was not populated'
@@ -483,7 +483,7 @@ jobs:
       - id: pnpm
         uses: ./
         with:
-          version: '12.0.0-alpha.21'
+          version: '12.0.0-beta.4'
 
       - name: 'Test: pnpm works, runtime outputs are empty'
         env:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If your `package.json` declares `devEngines.runtime`, the action picks up the ru
 ```json
 // package.json
 {
-  "packageManager": "pnpm@12.0.0-alpha.19",
+  "packageManager": "pnpm@12.0.0-beta.4",
   "devEngines": {
     "runtime": { "name": "node", "version": "^22.0.0", "onFail": "download" }
   }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Install pnpm **and** a JavaScript runtime (Node.js, Bun, or Deno) in a single Gi
 pnpm ships a self-contained release binary — the action downloads it for the runner's platform directly from pnpm's GitHub releases (no Node.js or npm needed) and then uses `pnpm runtime set` to install the requested runtime. The runtime binary is placed on `PATH` for subsequent steps, replacing the need for `actions/setup-node`, `oven-sh/setup-bun`, or `denoland/setup-deno`. `pnpm install` runs automatically when a `package.json` is present.
 
 > [!NOTE]
-> This action installs pnpm v11 and newer only — it relies on pnpm's self-contained release binaries and the `pnpm runtime` command, both available from v11. To install pnpm 10 or older, use [`pnpm/action-setup`](https://github.com/pnpm/action-setup) instead.
+> `pnpm/setup@v2` installs pnpm v11 and newer only — it relies on pnpm's self-contained release binaries and the `pnpm runtime` command, both available from v11. `v1` installed pnpm through npm and could set up pnpm 10; if you need pnpm 10 or older, use [`pnpm/action-setup`](https://github.com/pnpm/action-setup) instead.
 >
 > One caveat: pnpm v11 publishes no binary for Intel macOS (`darwin-x64`); use v12 or newer on Intel macOS runners.
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/setup@v1
+      - uses: pnpm/setup@v2
       - run: node --version
       - run: pnpm test
 ```
@@ -71,7 +71,7 @@ jobs:
         node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/setup@v1
+      - uses: pnpm/setup@v2
         with:
           runtime: node@${{ matrix.node }}
       - run: pnpm test
@@ -80,11 +80,11 @@ jobs:
 ### Install Bun or Deno
 
 ```yaml
-- uses: pnpm/setup@v1
+- uses: pnpm/setup@v2
   with:
     runtime: bun@latest
 
-- uses: pnpm/setup@v1
+- uses: pnpm/setup@v2
   with:
     runtime: deno@2
 ```
@@ -92,7 +92,7 @@ jobs:
 ### Cache the pnpm store
 
 ```yaml
-- uses: pnpm/setup@v1
+- uses: pnpm/setup@v2
   with:
     cache: true
 ```
@@ -102,7 +102,7 @@ jobs:
 For jobs that only need pnpm itself — e.g. `pnpm audit`, lockfile-only regeneration — set `install: false`:
 
 ```yaml
-- uses: pnpm/setup@v1
+- uses: pnpm/setup@v2
   with:
     install: false
 - run: pnpm audit

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   version:
     description: |
-      Version of pnpm to install: an exact version (`12.0.0-alpha.17`), a
+      Version of pnpm to install: an exact version (`12.0.0-beta.4`), a
       semver range (`^12.0.0`), or an npm dist-tag (`next-12`). Must resolve
       to pnpm v11 or newer — the action downloads pnpm's native per-platform
       executable directly, without needing Node.js or npm.


### PR DESCRIPTION
Two docs/CI changes ahead of the next release.

## Reference `v2` in examples

The upcoming release drops pnpm 10 and older, so it goes out as `v2` rather than moving the `v1` tag. The README examples now point at the new major.

`v1` (`5d160c5`) installed pnpm by `npm ci`-ing `@pnpm/exe` and then running `pnpm self-update <version>`; `main` downloads the self-contained release binary from pnpm's GitHub releases and enforces `MIN_SUPPORTED_MAJOR = 11`. Reproducing v1's flow locally with its own bootstrap (`@pnpm/exe@11.7.0`) confirms pnpm 10 really did work there:

```
$ pnpm self-update 10.20.0
Switching pnpm from v11.7.0 to v10.20.0... Successfully updated
$ <PNPM_HOME>/bin/pnpm --version
10.20.0
```

So moving `v1` would hard-fail anyone on `packageManager: pnpm@10.x`. The input/output surface is otherwise compatible — nothing removed or renamed, `token` added with a default — but that's a real break, and `6bfbb82`'s `feat!` marker was right.

The "v11 and newer only" note now spells out that v1 could set up pnpm 10, so a v1 user whose workflow breaks on the upgrade finds the explanation rather than a bare version requirement that contradicts their experience.

### Context

This came out of a report of `@v1` failing with:

```
.../global/v11/…/node_modules/@pnpm/exe/pnpm: 1: This: not found
Error: The process '.../node_modules/.bin/bin/pnpm' failed with exit code 127
```

That is isolated to pnpm 11.13.0, whose `@pnpm/exe` npm artifact ships the unreplaced `This file intentionally left blank` placeholder instead of the platform binary (now deprecated on npm; `pnpm/action-setup` rejects it with `ERR_PNPM_BROKEN_PNPM_RELEASE`). The 11.13.0 *GitHub release* asset is fine — it extracts to a real ELF binary reporting `11.13.0` — which is why pinning `pnpm/setup` to a `main` commit fixes it, and why `v2` is immune by construction. `v2` also fails loudly rather than silently on a bad artifact: `runSelfInstaller` runs `pnpm --version` after extraction and compares against the requested version.

## Update pnpm to v12.0.0-beta.4

v12 moved from alpha to beta — `next-12` now resolves to `12.0.0-beta.4`. Bumps the CI pins (`12.0.0-alpha.21`), the README example (`12.0.0-alpha.19`), and the `action.yml` sample version (`12.0.0-alpha.17`). The release ships the full asset set, including the `darwin-x64` build v11 lacks.

No `src/` or `dist/` changes in either commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup examples to use the latest pnpm action version.
  * Clarified that the newer action supports pnpm v11 and above.
  * Added guidance for migrating from the previous action version.
  * Refreshed documented pnpm version examples.

* **Tests**
  * Updated workflow test scenarios to validate pnpm `12.0.0-beta.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->