### PR TITLE
docs(README): bump versions (node, action/setup)

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -14,7 +14,7 @@ jobs:
     # Guarantees the committed dist/index.js matches the current source.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
             version: '12.0.0-beta.4'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - id: pnpm
         uses: ./
@@ -69,7 +69,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - id: pnpm
         uses: ./
@@ -102,7 +102,7 @@ jobs:
     name: 'Runtime node + install on pnpm 11'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up a synthetic package.json
         # Use a fresh manifest (and drop the repo lockfile) so `pnpm install`
@@ -160,7 +160,7 @@ jobs:
     name: 'Version from dist-tag (next-12)'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./
         with:
@@ -185,7 +185,7 @@ jobs:
     name: 'Version from semver range (^12.0.0-0)'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./
         with:
@@ -220,7 +220,7 @@ jobs:
             major: '22'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - id: pnpm
         uses: ./
@@ -263,7 +263,7 @@ jobs:
     name: Runtime bun
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           version: '12.0.0-beta.4'
@@ -279,7 +279,7 @@ jobs:
     name: Runtime deno
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           version: '12.0.0-beta.4'
@@ -298,7 +298,7 @@ jobs:
     name: 'Runtime from devEngines.runtime'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up package.json with devEngines.runtime
         # Remove the action's own pnpm-lock.yaml so `pnpm install` doesn't
@@ -357,7 +357,7 @@ jobs:
     name: 'Explicit runtime overrides devEngines.runtime'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up package.json with conflicting devEngines.runtime
         run: |
@@ -402,7 +402,7 @@ jobs:
     name: 'runtime version falls back to devEngines'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up package.json with devEngines.runtime version
         run: |
@@ -439,7 +439,7 @@ jobs:
     name: 'install: false skips pnpm install'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up package.json with a dependency
         run: |
@@ -478,7 +478,7 @@ jobs:
     name: 'No runtime, no manifest'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - id: pnpm
         uses: ./

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/setup@v2
       - run: node --version
       - run: pnpm test
@@ -68,9 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/setup@v2
         with:
           runtime: node@${{ matrix.node }}


### PR DESCRIPTION
This PR bumps versions in `README.md`.
This PR also bumps versions of `actions/checkout` in the test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Actions examples to use the latest checkout action version.
  * Updated the Node.js test matrix to cover versions 22, 24, and 26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->