### PR TITLE
ci: update dependencies with pnpm/update instead of Dependabot

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,47 @@
+name: Update Dependencies
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # Mondays, 04:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-dependencies
+  cancel-in-progress: false
+
+jobs:
+  update-dependencies:
+    # The branch push and the pull request both target this repository, so
+    # this must never run on a fork.
+    if: github.repository == 'pnpm/setup'
+    name: 'Update dependencies'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # This repository's own action, on the pnpm it ships. `install: false`
+      # because pnpm/update deletes the lockfile and node_modules before it
+      # resolves anything, so installing first would be thrown away.
+      - uses: ./
+        with:
+          version: '^12.0.0'
+          install: false
+
+      - uses: pnpm/update@v0
+        with:
+          # `dist/index.js` is committed, and pr-check rebuilds it and fails on
+          # any difference. Every runtime dependency is inlined into that
+          # bundle, and esbuild itself decides how — so it has to be
+          # regenerated in the same commit as the bump, or the update pull
+          # request can never go green. This is the step Dependabot had no way
+          # to run.
+          post-update: pnpm run build
+          verify: |
+            pnpm exec tsc --noEmit
+            pnpm test
+          # No .changeset directory in this repository.
+          changesets: false


### PR DESCRIPTION
Replaces Dependabot for dependency updates. Closes #5 once merged.

## Why

Dependabot cannot open a passing pull request against this repository. `dist/index.js` is committed, and `pr-check` rebuilds it and fails on any difference — but a bump only touches `package.json` and `pnpm-lock.yaml`, so the committed bundle is always the one built by the *previous* dependency set.

That is exactly why #5 is red. esbuild 0.28 changed the CommonJS init helpers it emits:

```js
// 0.27.7
var h=(t,e)=>()=>(e||t((e={exports:{}}).exports,e),e.exports),

// 0.28.1
var h=(t,e)=>()=>{try{return e||t((e={exports:{}}).exports,e),e.exports}catch(r){throw e=0,r}},
```

A real change, so a real diff, so `git diff --exit-code dist/index.js` fails. And it is not specific to esbuild: all twelve runtime dependencies are inlined into that bundle, so any bump can move it.

## What this does

`pnpm/update` has a `post-update` hook that runs before it commits, so `pnpm run build` regenerates the bundle in the same commit as the bump — the step Dependabot had no way to run.

```yaml
- uses: pnpm/update@v0
  with:
    post-update: pnpm run build
    verify: |
      pnpm exec tsc --noEmit
      pnpm test
    changesets: false
```

`verify` typechecks and runs the unit tests before the commit is made; the resulting pull request then gets the full matrix from `test.yaml`.

Runs weekly on Mondays and on demand via `workflow_dispatch`, guarded with `if: github.repository == 'pnpm/setup'` so it never runs on a fork.

## Notes

- The setup step uses `./` rather than a released tag, so the update runs on the pnpm this action ships. `install: false`, because `pnpm/update` deletes the lockfile and `node_modules` before resolving anything.
- `changesets: false` — no `.changeset` directory here.
- `github-actions` is left at its default (`false`), so pinned action versions in the workflows are not touched. Worth turning on separately if you want that too; it matches what Dependabot was not doing either.
- There is no `.github/dependabot.yml` in the repository, so #5 came from a repository-level Dependabot setting rather than a config file. Turning it off is a change in the repository settings, not something this PR can do.
